### PR TITLE
Fix potential problems reported by shellcheck

### DIFF
--- a/console
+++ b/console
@@ -6,7 +6,7 @@ function help {
 	echo "Remote Environment client."
 	echo
 	echo "Usage:"
-	echo "  "$0" command"
+	echo "  ${0} command"
 	echo 
 	echo "Available commands:"
 	echo "   setup             Setup the remote environment client and settings"
@@ -30,24 +30,24 @@ command_exists () {
 }
 
 function dir {
-    echo $CALLING_DIR
+    echo "$CALLING_DIR"
 }
 
 function remote_name {
-    echo $(read_setting 3)
+    read_setting 3
 }
 
 function remote_branch {
-    echo $(read_setting 2)
+    read_setting 2
 }
 
 function namespace {
-    echo $(read_setting 1)
+    read_setting 1
 }
 
 function pod {
     CONTAINER=$1
-    echo `kubectl --context=$(namespace) --namespace=$(namespace) get pods | grep $CONTAINER | awk '{print $1}'`
+    kubectl --context="$(namespace)" --namespace="$(namespace)" get pods | grep "$CONTAINER" | awk '{print $1}'
 }
 
 function pod_found {
@@ -60,16 +60,16 @@ function pod_found {
 }
 
 function local_branch {
-    echo `git rev-parse --abbrev-ref HEAD`
+    git rev-parse --abbrev-ref HEAD
 }
 
 function read_setting {
-    SETTING=`sed "$1q;d" $(dir)/.remote`
+    SETTING="$(sed "$1q;d" "$(dir)/.remote")"
     if [ -z "$SETTING" ]; then
         echo "The remote settings are missing, please run the setup command"
         exit;
     fi
-    echo $SETTING
+    echo "$SETTING"
 }
 
 function setup {
@@ -91,24 +91,24 @@ function setup {
 	
 	REMOTE_DIR="$(dir)/.remote"
     
-    read -p "What is your remove development namespace? " NAMESPACE
-    read -p "What is the name of the Git branch you are using for your remote environment? " REMOTE_BRANCH
-    read -p "What is your github remote name? (origin) " REMOTE_NAME
-    read -p "What is the IP of the cluster? " CLUSTER_IP
-    read -p "What is the username? " USERNAME
-    read -p "What is the password? " PASSWORD
+    read -r -p "What is your remove development namespace? " NAMESPACE
+    read -r -p "What is the name of the Git branch you are using for your remote environment? " REMOTE_BRANCH
+    read -r -p "What is your github remote name? (origin) " REMOTE_NAME
+    read -r -p "What is the IP of the cluster? " CLUSTER_IP
+    read -r -p "What is the username? " USERNAME
+    read -r -p "What is the password? " PASSWORD
 
-    REMOTE_NAME=${REMOTE_NAME:-origin}
-    echo $NAMESPACE > $REMOTE_DIR
-    echo $REMOTE_BRANCH >> $REMOTE_DIR
-    echo $REMOTE_NAME >> $REMOTE_DIR
+    REMOTE_NAME="${REMOTE_NAME:-origin}"
+    echo "$NAMESPACE" > "$REMOTE_DIR"
+    echo "$REMOTE_BRANCH" >> "$REMOTE_DIR"
+    echo "$REMOTE_NAME" >> "$REMOTE_DIR"
     echo "Remote settings written to $REMOTE_DIR"
 
-    kubectl config set-credentials $NAMESPACE-$USERNAME --username=$USERNAME --password=$PASSWORD
-    kubectl config set-cluster $NAMESPACE --server=https://$CLUSTER_IP --insecure-skip-tls-verify=true
-    kubectl config set-context $NAMESPACE --cluster=$NAMESPACE --user=$NAMESPACE-$USERNAME
+    kubectl config set-credentials "$NAMESPACE-$USERNAME" --username="$USERNAME" --password="$PASSWORD"
+    kubectl config set-cluster "$NAMESPACE" --server="https://$CLUSTER_IP" --insecure-skip-tls-verify=true
+    kubectl config set-context "$NAMESPACE" --cluster="$NAMESPACE" --user="$NAMESPACE-$USERNAME"
 
-    echo "Created the context " $NAMESPACE
+    echo "Created the context " "$NAMESPACE"
     echo
     echo "Run 'kubectl --context=$(namespace) cluster-info' to verify the connectivity."
     echo
@@ -120,17 +120,17 @@ function build {
 }
 
 function ensure_new_commit {
-    git diff --exit-code --quiet $(local_branch) $(remote_name)/$(remote_branch)
+    git diff --exit-code --quiet "$(local_branch)" "$(remote_name)/$(remote_branch)"
     rc=$?; if [[ $rc = 0 ]]; then
         echo "No changes so making timestamp update only commit to force rebuild";
-        gdate +%s > $DIR/../timestamp
-        git commit $DIR/../timestamp -m "Update timestamp to force rebuild on continuous pipe"
+        gdate +%s > "$DIR/../timestamp"
+        git commit "$DIR/../timestamp" -m "Update timestamp to force rebuild on continuous pipe"
     fi
 }
 
 function push_to_remote {
     echo "Pushing to remote"
-    git push --force $(remote_name) $(local_branch):$(remote_branch)
+    git push --force "$(remote_name)" "$(local_branch):$(remote_branch)"
 
     echo "Continuous Pipe will now build your developer environment"
 }
@@ -138,54 +138,54 @@ function push_to_remote {
 function delete_remote {
     echo "Destroying remote environment"
     echo "Deleting remote branch"
-    git push $(remote_name) --delete $(remote_branch)
+    git push "$(remote_name)" --delete "$(remote_branch)"
 
     echo "Continuous Pipe will now destroy the remote environment"
 }
 
 function ssh {
-    POD=$(pod $1)
-    pod_found $POD
-    cmd="kubectl --context=$(namespace) --namespace=$(namespace) exec -it $POD -- /bin/bash"
+    POD="$(pod "$1")"
+    pod_found "$POD"
+    cmd="kubectl --context=\"$(namespace)\" --namespace=\"$(namespace)\" exec -it $POD -- /bin/bash"
     echo "Running: '${cmd}'."
-    eval ${cmd}
+    eval "${cmd}"
 }
 
 function watch {
     # Sync latency / speed in seconds
     LATENCY="1"
     PROJECT_DIR_WITH_DOT="$(dir)/."
-    POD=$(pod $1)
-    pod_found $POD
+    POD="$(pod "$1")"
+    pod_found "$POD"
 
     echo "The watch command will need to be restarted after rebuilding the remote environment"
     # Watch for changes and sync (exclude hidden files)
     echo    "Watching for changes. Quit anytime with Ctrl-C."
-    fswatch -0 -r -l $LATENCY .. --exclude="/\.[^/]*$" --exclude="\.idea" --exclude="\.git" --exclude="___jb_old___" --exclude="___jb_tmp___" \
-    | while read -d "" event
+    fswatch -0 -r -l "$LATENCY" .. --exclude="/\.[^/]*$" --exclude="\.idea" --exclude="\.git" --exclude="___jb_old___" --exclude="___jb_tmp___" \
+    | while read -r -d "" event
       do
-        echo `date` "\"$event\" changed. Synchronizing... "
+        echo "$(date)" "\"$event\" changed. Synchronizing... "
         file="${event/$(dir)/$PROJECT_DIR_WITH_DOT}"
-        echo $result_string
+        echo
 
-        rsync --relative -rlptDv -e 'kubectl --context='$(namespace)' --namespace='$(namespace)' exec -i '$POD -- $file --:/app
+        rsync --relative -rlptDv -e 'kubectl --context='"$(namespace)"' --namespace='"$(namespace)"' exec -i '"$POD" -- "$file" --:/app
         echo "done."
       done
 }
 
 function resync {
-    POD=$(pod $1)
-    pod_found $POD
+    POD=$(pod "$1")
+    pod_found "$POD"
 
     git stash save -q --keep-index
 
     rsync -zrlptDv --blocking-io  --force --exclude=".*" \
-        -e 'kubectl --context='$(namespace)' --namespace='$(namespace)' exec -i '$POD -- --:/app/ $(dir)
+        -e 'kubectl --context='"$(namespace)"' --namespace='"$(namespace)"' exec -i '"$POD" -- --:/app/ "$(dir)"
 
     git reset --hard -q && git stash apply --index -q && git stash drop -q
 
     rsync -zrlptDv --blocking-io  --force --exclude=".*" \
-        -e 'kubectl  --context='$(namespace)' --namespace='$(namespace)' exec -i '$POD -- $(dir)/. --:/app
+        -e 'kubectl  --context='"$(namespace)"' --namespace='"$(namespace)"' exec -i '"$POD" -- "$(dir)/." --:/app
 }
 
 case $1 in
@@ -194,14 +194,14 @@ case $1 in
     exit 0
     ;;
     setup|create|build|watch|ssh|destroy|resync)
-    COMMAND=$1
+    COMMAND="$1"
     ;;
     *)
-        echo "Unknown option: "$1
+        echo "Unknown option: $1"
     ;;
 esac
 
-if [ -z ${COMMAND+x} ]; then
+if [ -z "${COMMAND+x}" ]; then
 	help
 	exit 0
 fi
@@ -214,25 +214,25 @@ case $COMMAND in
     	push_to_remote
     	;;
     watch)
-        container_specified $2
-        watch $2
+        container_specified "$2"
+        watch "$2"
         ;;
     build)
         build
         ;;
     ssh)
-        container_specified $2
-        ssh $2
+        container_specified "$2"
+        ssh "$2"
         ;;
     destroy)
         delete_remote
         ;;
     resync)
-        container_specified $2
-        resync $2
+        container_specified "$2"
+        resync "$2"
         ;;
 	*)
-		echo "Command not found: "$COMMAND
+		echo "Command not found: $COMMAND"
 		echo
 		help
 		exit 1


### PR DESCRIPTION
Requires testing.

Fix potential problems reported by [shellcheck](https://github.com/koalaman/shellcheck) script static analysis tool.

Mostly surrounding the quoting of variables and removal of echo's.
`read -r` apparently doesn't mangle backslashes whereas they are mangled if you leave off the `-r`, but might not be what we want!