### PR TITLE
Change build to use an empty commit if no changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The `build` command will push changes the branch you have checked out locally to
  To rebuild your remote environment to use the current branch you have checked out you can use the 
   `build` command. This will force push the current branch which will make Continuous Pipe rebuild the
   environment. If the remote environment has the latest commit then it would not be rebuilt, in order
-  to force the rebuild a commit is automatically made updating a timestamp file.
+  to force the rebuild an empty commit is automatically made.
  
 ## Watch
  

--- a/cp-remote
+++ b/cp-remote
@@ -228,10 +228,8 @@ function ensure_new_commit {
 
     git diff --exit-code --quiet "$(local_branch)" "$(remote_name)/$(remote_branch)"
     rc=$?; if [[ $rc = 0 ]]; then
-        echo "No changes so making timestamp update only commit to force rebuild";
-        date +%s > "$(dir)/timestamp"
-        git add "$(dir)/timestamp"
-        git commit "$(dir)/timestamp" -m "Update timestamp to force rebuild on continuous pipe"
+        echo "No changes so making an empty commit to force rebuild";
+        git commit --allow-empty -m "Add empty commit to force rebuild on continuous pipe"
     fi
 }
 


### PR DESCRIPTION
This means there doesn't need to be any changes in the commit so timestamp file isn't needed