### PR TITLE
Add rsync excludes file for more control

### DIFF
--- a/cp-remote
+++ b/cp-remote
@@ -66,7 +66,14 @@ function settings_file {
 }
 
 function excludes_file {
-    echo "$(dir)/cp-remote-excludes.txt"
+
+    EXCLUDES_FILE="$(dir)/cp-remote-excludes.txt"
+
+    if [ ! -f "${EXCLUDES_FILE}" ]; then
+        touch "${EXCLUDES_FILE}"
+    fi
+
+    echo "${EXCLUDES_FILE}"
 }
 
 function project_key {
@@ -171,10 +178,6 @@ function setup {
 	fi
 	
 	REMOTE_DIR="$(settings_file)"
-
-    if [ ! -f "$(excludes_file)" ]; then
-        touch $(excludes_file)
-    fi
     
     read -r -p "What is your Continuous Pipe project key? " PROJECT_KEY
     read -r -p "What is the name of the Git branch you are using for your remote environment? " REMOTE_BRANCH

--- a/cp-remote
+++ b/cp-remote
@@ -65,6 +65,10 @@ function settings_file {
     echo "$(dir)/.cp-remote-env-settings"
 }
 
+function excludes_file {
+    echo "$(dir)/cp-remote-excludes.txt"
+}
+
 function project_key {
     echo "$PROJECT_KEY"
 }
@@ -167,6 +171,10 @@ function setup {
 	fi
 	
 	REMOTE_DIR="$(settings_file)"
+
+    if [ ! -f "$(excludes_file)" ]; then
+        touch $(excludes_file)
+    fi
     
     read -r -p "What is your Continuous Pipe project key? " PROJECT_KEY
     read -r -p "What is the name of the Git branch you are using for your remote environment? " REMOTE_BRANCH
@@ -303,7 +311,7 @@ function watch {
         file="${event/$(dir)/$PROJECT_DIR_WITH_DOT}"
         echo
 
-        rsync --relative -rlptDv -e 'kubectl --context='"$(context)"' --namespace='"$(namespace)"' exec -i '"$POD" -- "$file" --:/app
+        rsync --relative -rlptDv --exclude-from=$(excludes_file) -e 'kubectl --context='"$(context)"' --namespace='"$(namespace)"' exec -i '"$POD" -- "$file" --:/app
         echo "done."
         anybar green
       done
@@ -322,12 +330,12 @@ function resync {
         exit
     fi
     anybar red
-    rsync -zrlptDv --blocking-io  --force --exclude=".*" \
+    rsync -zrlptDv --blocking-io  --force --exclude=".*" --exclude-from="$(excludes_file)"  \
         -e 'kubectl --context='"$(context)"' --namespace='"$(namespace)"' exec -i '"$POD" -- --:/app/ "$(dir)"
 
     git reset --hard -q && git stash apply --index -q && git stash drop -q
 
-    rsync -zrlptDv --blocking-io  --force --exclude=".*" \
+    rsync -zrlptDv --blocking-io  --force --exclude=".*" --exclude-from="$(excludes_file)" \
         -e 'kubectl  --context='"$(context)"' --namespace='"$(namespace)"' exec -i '"$POD" -- "$(dir)/." --:/app
 
     anybar green
@@ -340,7 +348,7 @@ function fetch {
     POD=$(pod "$1")
     pod_found "$POD"
 
-    rsync -zrlptDv --blocking-io  --force --exclude=".*" \
+    rsync -zrlptDv --blocking-io  --force --exclude=".*" --exclude-from="$(excludes_file)" \
         -e 'kubectl --context='"$(context)"' --namespace='"$(namespace)"' exec -i '"$POD" -- --:/app/ "$(dir)"
 
     anybar green

--- a/cp-remote
+++ b/cp-remote
@@ -67,7 +67,7 @@ function settings_file {
 
 function excludes_file {
 
-    EXCLUDES_FILE="$(dir)/cp-remote-excludes.txt"
+    EXCLUDES_FILE="$(dir)/.cp-remote-ignore"
 
     if [ ! -f "${EXCLUDES_FILE}" ]; then
         touch "${EXCLUDES_FILE}"


### PR DESCRIPTION
Given the differences in project types it would be better to provide the user more control over which files get synced with the remote for both `resync` and `watch` commands.

This PR adds a `cp-remote-excludes.txt` file to the root of the project on setup and is used in all `rsync` commands with `--exclude-from=` option. For existing projects an empty `cp-remote-excludes.txt` must be created otherwise `rsync` will fail.

A scenario where this is useful is perhaps the user is using both local docker and cp-remote. We would want to avoid syncing the logs from the application when run in local docker compared to cp-remote. 

Or perhaps we have an SQL dump in the root of the project for backup only, we wouldn't want to rsync this to the remote. 

**Note: While looking at the documentation, I couldn't find an equivalent `--exclude-from` option for `fswatch`. So since it cannot read from the excludes list, it reports as though it is syncing the file, but in the background rsync will ignore the command for the changed file if it is in the excludes list**