### PR TITLE
[WIP] Use getopts for the option processing 

### DIFF
--- a/cp-remote
+++ b/cp-remote
@@ -2,22 +2,25 @@
 CALLING_DIR=$(pwd)
 
 function help {
-	echo "Remote Environment client."
-	echo
-	echo "Usage:"
-	echo "  ${0} command"
-	echo 
-	echo "Available commands:"
-	echo "   setup             Setup the remote environment client and settings"
-	echo "   build             Create/Update the remote environment"
-	echo "   watch             Watch local changes and synchronize with the remote environment"
-	echo "   bash              Open a bash session in the remote environment container"
-	echo "   fetch             Sync remote changes to the local filesystem"
-	echo "   resync            Sync remote changes to and from the local filesystem"
-	echo "   forward           Forward a port to a container"
-	echo "   destroy           Destroy the remote environment"
-	echo "   checkconnection   Check the connection to the remote environment"
-	echo "   checkversion      Check for updates to this tool"
+cat << EOF
+
+Remote Environment client.
+
+Usage:
+  ${0} command
+
+Available commands:
+   setup             Setup the remote environment client and settings
+   build             Create/Update the remote environment
+   watch             Watch local changes and synchronize with the remote environment
+   bash              Open a bash session in the remote environment container
+   fetch             Sync remote changes to the local filesystem
+   resync            Sync remote changes to and from the local filesystem
+   forward           Forward a port to a container
+   destroy           Destroy the remote environment
+   checkconnection   Check the connection to the remote environment
+   checkversion      Check for updates to this tool
+EOF
 }
 
 function open_anybar {
@@ -266,7 +269,7 @@ function push_to_remote {
     echo
     echo "You can see when it is complete and find its IP address at https://ui.continuouspipe.io/"
     echo
-    echo "Please wait unti the build is complete to use any of this tool's other commands."
+    echo "Please wait until the build is complete to use any of this tool's other commands."
     echo
 }
 
@@ -422,6 +425,11 @@ function check_connection {
     fi
 }
 
+if [[ -z "$1" ]]; then
+	help
+	exit 0
+fi
+
 case $1 in
     -h|--help|help)
     help
@@ -440,18 +448,23 @@ if [ -z "${COMMAND+x}" ]; then
 	exit 0
 fi
 
-for i in "$@"
-do
-    case $i in
-        -n=*|--namespace=*)
-        CUSTOM_NAMESPACE="${i#*=}"
-        shift # past argument=value
-        ;;
-        *)
-                # unknown option
-        ;;
-    esac
+shift
+
+while getopts "c:e:" opt; do
+  case $opt in
+    c)
+      SPECIFIED_CONTAINER=$OPTARG
+      ;;
+    e)
+      CUSTOM_NAMESPACE=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      ;;
+  esac
 done
+
+shift $((OPTIND-1))
 
 case $COMMAND in
 	setup)
@@ -459,8 +472,8 @@ case $COMMAND in
 		;;
     watch)
         validate_settings
-        container_specified "$2"
-        watch "$(container "$2")"
+        container_specified "$SPECIFIED_CONTAINER"
+        watch "$(container "$SPECIFIED_CONTAINER")"
         ;;
     build)
         validate_settings
@@ -468,13 +481,13 @@ case $COMMAND in
         ;;
     bash)
         validate_settings
-        container_specified "$2"
-        bash "$(container "$2")"
+        container_specified "$SPECIFIED_CONTAINER"
+        bash "$(container "$SPECIFIED_CONTAINER")"
         ;;
     ssh)
         validate_settings
-        container_specified "$2"
-        ssh "$(container "$2")"
+        container_specified "$SPECIFIED_CONTAINER"
+        ssh "$(container "$SPECIFIED_CONTAINER")"
         ;;
     destroy)
         validate_settings
@@ -482,18 +495,18 @@ case $COMMAND in
         ;;
     resync)
         validate_settings
-        container_specified "$2"
-        resync "$(container "$2")"
+        container_specified "$SPECIFIED_CONTAINER"
+        resync "$(container "$SPECIFIED_CONTAINER")"
         ;;
     fetch)
         validate_settings
-        container_specified "$2"
-        fetch "$(container "$2")"
+        container_specified "$SPECIFIED_CONTAINER"
+        fetch "$(container "$SPECIFIED_CONTAINER")"
         ;;
     forward)
-        container_specified "$2"
+        container_specified "$SPECIFIED_CONTAINER"
         validate_settings
-        port_forward "$2" "$3" "$4"
+        port_forward "$(container "$SPECIFIED_CONTAINER")" "$1" "$2"
         ;;
     checkconnection)
         validate_settings


### PR DESCRIPTION
Move to using getopts for option processing. This will mean there are b/c breaks in usage but if this makes sense it's probably as good a time as any to make the change. 

There is still a need to be specific about the order so 

```
cp-remote command options arguments
```

Getopts also doesn't support long option names in a straightforward way so it means switching to short options only.

I've also made specifying the container an option since it's optional and renamed -n/--namespace to -e since the thing it specifies are referred to as environments on CP and the readme here already.