### PR TITLE
Listing pods

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -21,6 +21,14 @@ cp-push pu
 cp-push pu -e techup-dev-user -s web
 `
 
+func NewSyncCmd() *cobra.Command {
+	pu := NewPushCmd()
+	pu.Use = "sync"
+	pu.Short = "Sync local changes to the remote filesystem (alias for push)"
+	pu.Aliases = []string{"sy"}
+	return pu
+}
+
 func NewPushCmd() *cobra.Command {
 	settings := config.C
 	handler := &PushHandle{}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,18 +75,20 @@ func Execute() {
 func init() {
 	RootCmd.PersistentFlags().StringVar(&localConfigFile, "config", ".cp-remote-settings.yml", "local config file (default is .cp-remote-settings.yml in the directory cp-remote is run from.)")
 
-	RootCmd.AddCommand(NewBashCmd())
+	RootCmd.AddCommand(NewInitCmd())
 	RootCmd.AddCommand(NewBuildCmd())
-	RootCmd.AddCommand(NewCheckConnectionCmd())
-	RootCmd.AddCommand(NewCheckUpdatesCmd())
 	RootCmd.AddCommand(NewDestroyCmd())
+	RootCmd.AddCommand(NewListPodsCmd())
+	RootCmd.AddCommand(NewCheckConnectionCmd())
+	RootCmd.AddCommand(NewBashCmd())
 	RootCmd.AddCommand(NewExecCmd())
+	RootCmd.AddCommand(NewWatchCmd())
 	RootCmd.AddCommand(NewFetchCmd())
 	RootCmd.AddCommand(NewPushCmd())
+	RootCmd.AddCommand(NewSyncCmd())
 	RootCmd.AddCommand(NewForwardCmd())
-	RootCmd.AddCommand(NewInitCmd())
 	RootCmd.AddCommand(NewVersionCmd())
-	RootCmd.AddCommand(NewWatchCmd())
+	RootCmd.AddCommand(NewCheckUpdatesCmd())
 
 	//adding kubectl commands as hidden
 	kubeCtlCommand := kubectlcmd.NewKubectlCommand(kubectlcmdutil.NewFactory(nil), os.Stdin, os.Stdout, os.Stderr)


### PR DESCRIPTION
* `checkconnection` now lists the pods available for the environment
* added command `pods` as alias of `checkconnnection`
* added `sync` as alias of `push`