### PR TITLE
CD-314 RC - Skip exact matches only and delegate the rest to rsync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 #
 
 BINARY=cp-remote
-VERSION=0.1.0
+VERSION=0.1.1-beta.2
 
 GOROOT_FINAL=/usr/local/Cellar/go/1.7.4_2/libexec
 CONFIG_PKG=github.com/continuouspipe/remote-environment-client/config

--- a/sync/monitor/exclusions.go
+++ b/sync/monitor/exclusions.go
@@ -4,8 +4,6 @@ package monitor
 import (
 	"github.com/continuouspipe/remote-environment-client/config"
 	"os"
-	"regexp"
-	"strings"
 )
 
 const CustomExclusionsFile = ".cp-remote-ignore"
@@ -57,16 +55,6 @@ func (m Exclusion) MatchExclusionList(target string) (bool, error) {
 	for _, elem := range m.ignore.List {
 		//if is an exact match return true
 		if elem == target {
-			return true, nil
-		}
-
-		//otherwise escape the "." and try to match it as a regex
-		escapedElem := strings.Replace(elem, ".", `\.`, -1)
-		regex, err := regexp.Compile(escapedElem)
-		if err != nil {
-			return false, nil
-		}
-		if res := regex.MatchString(target); res == true {
 			return true, nil
 		}
 	}

--- a/sync/rsync/syncdaemon.go
+++ b/sync/rsync/syncdaemon.go
@@ -81,6 +81,14 @@ func (r *RSyncDaemon) Sync(paths []string) error {
 		"--checksum",
 		`--exclude=.git`}
 
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(SyncExcluded); err == nil {
+		args = append(args, fmt.Sprintf(`--exclude-from=%s`, cwd+"/"+SyncExcluded))
+	}
+
 	paths = slice.RemoveDuplicateString(paths)
 
 	paths, err = r.getRelativePathList(paths)
@@ -154,13 +162,6 @@ func (o RSyncDaemon) syncIndividualFiles(paths []string, args []string) error {
 
 func (o RSyncDaemon) syncAllFiles(paths []string, args []string) error {
 	remoteRsyncUrl := o.remoteRsync.GetRsyncURL(rsyncConfigSection, o.remoteProjectPath)
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	if _, err := os.Stat(SyncExcluded); err == nil {
-		args = append(args, fmt.Sprintf(`--exclude-from=%s`, cwd+"/"+SyncExcluded))
-	}
 	args = append(args,
 		"--relative",
 		"--",


### PR DESCRIPTION
When doing individual file sync, show rsync output in stdout and let rsync do is pattern matching (which is not regex) so in MatchExclusionList() only skip for exact matches (in any other case let rsync decide what to sync)