### PR TITLE
Demo-ing filepath.Join() instead of concats

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -117,7 +117,7 @@ func initLocalConfig() {
 		os.Exit(1)
 	}
 
-	config.C.SetConfigFile(config.LocalConfigType, pwd+string(os.PathSeparator)+localConfigFile)
+	config.C.SetConfigFile(config.LocalConfigType, filepath.Join(pwd, localConfigFile))
 
 	//create the config file if it does not exist
 	configFileUsed, err := config.C.ConfigFileUsed(config.LocalConfigType)
@@ -132,18 +132,18 @@ func initLocalConfig() {
 func initGlobalConfig() {
 	homedirPath, err := homedir.Dir()
 	checkErr(err)
-	globalConfigPath := homedirPath + string(os.PathSeparator) + ".cp-remote" + string(os.PathSeparator)
-	globalConfigName := "config.yml"
+	globalConfigPath := filepath.Join(homedirPath, ".cp-remote")
+	globalConfigFilePath := filepath.Join(globalConfigPath, "config.yml")
 
 	//create the directory
 	_ = os.Mkdir(globalConfigPath, 0755)
 
 	//create the global config file
-	_, err = os.OpenFile(globalConfigPath+globalConfigName, os.O_RDWR|os.O_CREATE, 0664)
+	_, err = os.OpenFile(globalConfigFilePath, os.O_RDWR|os.O_CREATE, 0664)
 	checkErr(err)
 
 	//set directory and file path in config
-	config.C.SetConfigFile(config.GlobalConfigType, globalConfigPath+globalConfigName)
+	config.C.SetConfigFile(config.GlobalConfigType, globalConfigFilePath)
 
 	//load config file
 	checkErr(config.C.ReadInConfig(config.GlobalConfigType))


### PR DESCRIPTION
It's quite the space saver.

💣 The refactoring changed the folder path a bit:

```golang
homedirPath + string(os.PathSeparator) + ".cp-remote" + string(os.PathSeparator)
// ~/.cp-remote/

filepath.Join(homedirPath, ".cp-remote")
// ~/.cp-remote
```
Note the missing trailing slash. Was there a particular reason for putting it there? Or was it just to make it easier to concat later?


Btw, when _creating_ files, Windows handles Linux-like fw-slashes just fine. So a path like `homedirPath + "/.cp-remote"` is cross-platform. When _reading_ file paths given by the system, that's when you'd use `os.PathSeparator` (e.g. for splitting).

But `filepath.Join()` has some other [features](https://github.com/golang/go/blob/9741f0275c79786e16bdbe7b8ddfeecda421181f/src/path/filepath/path.go#L202-L203), soweshouldstickwithit. 