### PR TITLE
CD-431: linux watch fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@
 
 
 BINARY=cp-remote
-VERSION=0.1.3.beta.2
+VERSION=0.1.3.rc.1
 
 CONFIG_PKG=github.com/continuouspipe/remote-environment-client/config
 LDFLAGS=-ldflags="-X ${CONFIG_PKG}.CurrentVersion=${VERSION}"

--- a/sync/monitor/exclusions.go
+++ b/sync/monitor/exclusions.go
@@ -79,6 +79,11 @@ func (m Exclusion) MatchExclusionList(target string) (bool, error) {
 		return false, err
 	}
 
+	//current working directory with relative path "." should always be included in the transfer
+	if target == "." {
+		return false, err
+	}
+
 	m.rsyncMatcherPath.AddPattern(m.ignore.List...)
 	matchIncluded, msg, err := m.rsyncMatcherPath.HasMatchAndIsIncluded(target)
 	if msg != "" {


### PR DESCRIPTION
The current working directory wasn't being watched
Fixed by avoiding to call the pattern matcher when the target is exactly . as cwd should always being watched