### PR TITLE
Patch: Removing glide.lock from Git ignore file (it's committed anyway).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ bin/
 .cp-remote-settings.yml
 .cp-remote-env-settings.yml
 cp-remote-go
-glide.lock
 .idea
 cp-remote-logs
 /.cp-remote-settings.yml


### PR DESCRIPTION
I guess this is just an artifact from the past that it's left behind? IntelliJ was warning me about it.