### PR TITLE
A pod is Running if the Status Reason is also "Running"

### DIFF
--- a/cmd/checkconnection.go
+++ b/cmd/checkconnection.go
@@ -2,14 +2,15 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/continuouspipe/remote-environment-client/config"
 	"github.com/continuouspipe/remote-environment-client/kubectlapi"
 	"github.com/continuouspipe/remote-environment-client/kubectlapi/pods"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"k8s.io/kubernetes/pkg/kubectl"
-	"os"
-	"strings"
 )
 
 func NewListPodsCmd() *cobra.Command {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"strings"
 
+	"io/ioutil"
+	"runtime"
+
 	"github.com/continuouspipe/remote-environment-client/config"
 	"github.com/continuouspipe/remote-environment-client/cpapi"
 	"github.com/continuouspipe/remote-environment-client/cplogs"
@@ -12,10 +15,8 @@ import (
 	"github.com/continuouspipe/remote-environment-client/kubectlapi/exec"
 	kexec "github.com/continuouspipe/remote-environment-client/kubectlapi/exec"
 	"github.com/continuouspipe/remote-environment-client/kubectlapi/pods"
-	"github.com/spf13/cobra"
-	"io/ioutil"
-	"runtime"
 	msgs "github.com/continuouspipe/remote-environment-client/messages"
+	"github.com/spf13/cobra"
 )
 
 var execExample = fmt.Sprintf(`
@@ -180,7 +181,7 @@ func (h *execHandle) Handle(podsFinder pods.Finder, podsFilter pods.Filter, exec
 		return err
 	}
 
-	pod := podsFilter.List(*podsList).ByService(h.service).ByStatus("Running").First()
+	pod := podsFilter.List(*podsList).ByService(h.service).ByStatus("Running").ByStatusReason("Running").First()
 	if pod == nil {
 		return fmt.Errorf(fmt.Sprintf(msgs.NoActivePodsFoundForSpecifiedServiceName, h.service))
 	}

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -136,7 +136,7 @@ func (h *FetchHandle) Handle(args []string, podsFinder pods.Finder, podsFilter p
 		return err
 	}
 
-	pod := podsFilter.List(*allPods).ByService(h.Service).ByStatus("Running").First()
+	pod := podsFilter.List(*allPods).ByService(h.Service).ByStatus("Running").ByStatusReason("Running").First()
 	if pod == nil {
 		return fmt.Errorf(fmt.Sprintf(msgs.NoActivePodsFoundForSpecifiedServiceName, h.Service))
 	}

--- a/cmd/forward.go
+++ b/cmd/forward.go
@@ -130,7 +130,7 @@ func (h *ForwardHandle) Handle() error {
 		return err
 	}
 
-	pod := h.podsFilter.List(*allPods).ByService(h.Service).ByStatus("Running").First()
+	pod := h.podsFilter.List(*allPods).ByService(h.Service).ByStatus("Running").ByStatusReason("Running").First()
 	if pod == nil {
 		return fmt.Errorf(fmt.Sprintf(msgs.NoActivePodsFoundForSpecifiedServiceName, h.Service))
 	}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -131,7 +131,7 @@ func (h *LogsCmdHandle) Handle(args []string, podsFinder pods.Finder, podsFilter
 		return err
 	}
 
-	pod := podsFilter.List(*allPods).ByService(h.service).ByStatus("Running").First()
+	pod := podsFilter.List(*allPods).ByService(h.service).ByStatus("Running").ByStatusReason("Running").First()
 	if pod == nil {
 		return fmt.Errorf(fmt.Sprintf(msgs.NoActivePodsFoundForSpecifiedServiceName, h.service))
 	}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -168,7 +168,7 @@ func (h *PushHandle) Handle(args []string, podsFinder pods.Finder, podsFilter po
 		return err
 	}
 
-	pod := podsFilter.List(*allPods).ByService(h.options.service).ByStatus("Running").First()
+	pod := podsFilter.List(*allPods).ByService(h.options.service).ByStatus("Running").ByStatusReason("Running").First()
 	if pod == nil {
 		return fmt.Errorf(fmt.Sprintf(msgs.NoActivePodsFoundForSpecifiedServiceName, h.options.service))
 	}

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -2,20 +2,21 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/continuouspipe/remote-environment-client/config"
 	"github.com/continuouspipe/remote-environment-client/cpapi"
 	"github.com/continuouspipe/remote-environment-client/kubectlapi"
 	"github.com/continuouspipe/remote-environment-client/kubectlapi/pods"
+	msgs "github.com/continuouspipe/remote-environment-client/messages"
 	"github.com/continuouspipe/remote-environment-client/sync"
 	"github.com/continuouspipe/remote-environment-client/sync/monitor"
 	"github.com/continuouspipe/remote-environment-client/sync/options"
 	"github.com/continuouspipe/remote-environment-client/util"
 	"github.com/spf13/cobra"
-	"io"
-	"os"
-	"strings"
-	"time"
-	msgs "github.com/continuouspipe/remote-environment-client/messages"
 )
 
 func NewWatchCmd() *cobra.Command {
@@ -155,7 +156,7 @@ func (h *WatchHandle) Handle(dirMonitor monitor.DirectoryMonitor, podsFinder pod
 		return err
 	}
 
-	pod := podsFilter.List(*allPods).ByService(h.options.service).ByStatus("Running").First()
+	pod := podsFilter.List(*allPods).ByService(h.options.service).ByStatus("Running").ByStatusReason("Running").First()
 	if pod == nil {
 		return fmt.Errorf(fmt.Sprintf(msgs.NoActivePodsFoundForSpecifiedServiceName, h.options.service))
 	}

--- a/kubectlapi/pods/filter.go
+++ b/kubectlapi/pods/filter.go
@@ -1,14 +1,16 @@
 package pods
 
 import (
-	"k8s.io/kubernetes/pkg/api"
 	"strings"
+
+	"k8s.io/kubernetes/pkg/api"
 )
 
 type Filter interface {
 	List(pods api.PodList) Filter
 	ByService(service string) Filter
 	ByStatus(status string) Filter
+	ByStatusReason(reason string) Filter
 	First() *api.Pod
 }
 
@@ -47,6 +49,17 @@ func (p KubePodsFilter) ByStatus(status string) Filter {
 	filteredPodItems := p.podList.Items[:0]
 	for _, pod := range p.podList.Items {
 		if pod.Status.Phase == statusToPodPhase(status) {
+			filteredPodItems = append(filteredPodItems, pod)
+		}
+	}
+	p.podList.Items = filteredPodItems
+	return p
+}
+
+func (p KubePodsFilter) ByStatusReason(reason string) Filter {
+	filteredPodItems := p.podList.Items[:0]
+	for _, pod := range p.podList.Items {
+		if reason == statusReason(pod) {
 			filteredPodItems = append(filteredPodItems, pod)
 		}
 	}

--- a/kubectlapi/pods/filter_test.go
+++ b/kubectlapi/pods/filter_test.go
@@ -1,0 +1,50 @@
+package pods
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/util/node"
+)
+
+func TestKubePodsFilter(t *testing.T) {
+	podPending := api.Pod{}
+	podPending.Name = "mysql-881010915-wpndh"
+	podPending.Status = api.PodStatus{Phase: api.PodPending}
+
+	podFailed := api.Pod{}
+	podFailed.Name = "web-151435215-nsdaf"
+	podFailed.Status = api.PodStatus{Phase: api.PodFailed}
+
+	podUnknown := api.Pod{}
+	podUnknown.Name = "web-981327404-bargs"
+	podUnknown.Status = api.PodStatus{Phase: api.PodUnknown}
+
+	podTerminating := api.Pod{}
+	podTerminating.Name = "web-9263482738-axiwjs"
+	podTerminating.Status = api.PodStatus{Phase: api.PodRunning}
+	podTerminating.Status = api.PodStatus{Phase: api.PodRunning, Reason: node.NodeUnreachablePodReason}
+	podTerminating.DeletionTimestamp = &unversioned.Time{}
+
+	podRunning := api.Pod{}
+	podRunning.Name = "web-812374193-mxiwy"
+	podRunning.Status = api.PodStatus{Phase: api.PodRunning}
+
+	podSucceeded := api.Pod{}
+	podSucceeded.Name = "web-989823427-cosjd"
+	podSucceeded.Status = api.PodStatus{Phase: api.PodSucceeded}
+
+	podList := api.PodList{}
+	podList.Items = []api.Pod{
+		podPending,
+		podFailed,
+		podUnknown,
+		podRunning,
+		podSucceeded,
+	}
+
+	found := KubePodsFilter{podList}.ByService("web").ByStatus("Running").ByStatusReason("Running").First()
+	assert.Equal(t, "web-812374193-mxiwy", found.Name)
+}

--- a/kubectlapi/pods/pod.go
+++ b/kubectlapi/pods/pod.go
@@ -1,0 +1,69 @@
+package pods
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/node"
+)
+
+//statusReason returns the reason for the pod status, extracted from kuberentes resource_printer.go
+func statusReason(pod api.Pod) string {
+	initializing := false
+	reason := string(pod.Status.Phase)
+
+	if pod.Status.Reason != "" {
+		reason = pod.Status.Reason
+	}
+
+	for i := range pod.Status.InitContainerStatuses {
+		container := pod.Status.InitContainerStatuses[i]
+		switch {
+		case container.State.Terminated != nil && container.State.Terminated.ExitCode == 0:
+			continue
+		case container.State.Terminated != nil:
+			// initialization is failed
+			if len(container.State.Terminated.Reason) == 0 {
+				if container.State.Terminated.Signal != 0 {
+					reason = fmt.Sprintf("Init:Signal:%d", container.State.Terminated.Signal)
+				} else {
+					reason = fmt.Sprintf("Init:ExitCode:%d", container.State.Terminated.ExitCode)
+				}
+			} else {
+				reason = "Init:" + container.State.Terminated.Reason
+			}
+			initializing = true
+		case container.State.Waiting != nil && len(container.State.Waiting.Reason) > 0 && container.State.Waiting.Reason != "PodInitializing":
+			reason = "Init:" + container.State.Waiting.Reason
+			initializing = true
+		default:
+			reason = fmt.Sprintf("Init:%d/%d", i, len(pod.Spec.InitContainers))
+			initializing = true
+		}
+		break
+	}
+	if !initializing {
+		for i := len(pod.Status.ContainerStatuses) - 1; i >= 0; i-- {
+			container := pod.Status.ContainerStatuses[i]
+			if container.State.Waiting != nil && container.State.Waiting.Reason != "" {
+				reason = container.State.Waiting.Reason
+			} else if container.State.Terminated != nil && container.State.Terminated.Reason != "" {
+				reason = container.State.Terminated.Reason
+			} else if container.State.Terminated != nil && container.State.Terminated.Reason == "" {
+				if container.State.Terminated.Signal != 0 {
+					reason = fmt.Sprintf("Signal:%d", container.State.Terminated.Signal)
+				} else {
+					reason = fmt.Sprintf("ExitCode:%d", container.State.Terminated.ExitCode)
+				}
+			}
+		}
+	}
+
+	if pod.DeletionTimestamp != nil && pod.Status.Reason == node.NodeUnreachablePodReason {
+		reason = "Unknown"
+	} else if pod.DeletionTimestamp != nil {
+		reason = "Terminating"
+	}
+
+	return reason
+}

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -1,3 +1,3 @@
 package messages
 
-const NoActivePodsFoundForSpecifiedServiceName = "No active pods were found for the specified service name (%s)"
+const NoActivePodsFoundForSpecifiedServiceName = "No running pods were found for the specified service name (%s)"


### PR DESCRIPTION
After looking at the kubernetes code, looks like `pod.Status.Phase == "Running"` is not enough to determine that the pod status is "Running". 

`pod.Status.InitContainerStatuses`, `pod.Status.ContainerStatuses`, `pod.DeletionTimestamp` and `pod.Status.Reason` also have to be considered.

This changes fix the issue, as introduce a new filter "ByStatusReason"