### PR TITLE
Bugfix/cd 443 config default service not applied

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,10 +103,10 @@ func init() {
 
 	RootCmd.SetUsageTemplate(usageTemplate)
 
-	cobra.OnInitialize(initConfig)
+	cobra.OnInitialize(onInitialize)
 }
 
-func initConfig() {
+func onInitialize() {
 	checkLegacyApplicationFile()
 	addApplicationFilesToGitIgnore()
 }


### PR DESCRIPTION
Commands where getting instantiated before that the configs where read properly therefore defaults value where always being used.